### PR TITLE
proxy: fix tests

### DIFF
--- a/group.go
+++ b/group.go
@@ -135,6 +135,13 @@ func (pg *Group) closing() bool {
 	return pg.inClose.Load()
 }
 
+func (pg *Group) Proxy(stream Stream) *Proxy {
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+
+	return pg.proxies[stream]
+}
+
 // Stream represents a bidirectional data stream.
 type Stream struct {
 	listenNetwork, listenAddr string

--- a/group.go
+++ b/group.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -21,6 +22,10 @@ var (
 
 // Group represents a group of proxy servers.
 type Group struct {
+	// ErrorLog specifies an optional logger for errors. If nil,
+	// logging is done via the log package's standard logger.
+	ErrorLog *log.Logger
+
 	// BeforeAccept is called for every proxy once its listener is
 	// ready, just before accepting connections.
 	BeforeAccept func() error
@@ -69,7 +74,7 @@ func (pg *Group) ListenAndServe(streams []Stream) error {
 }
 
 func (pg *Group) handleStream(stream Stream) error {
-	p := &Proxy{}
+	p := &Proxy{ErrorLog: pg.ErrorLog}
 
 	if err := pg.trackProxy(stream, p, true); err != nil {
 		return err

--- a/group_test.go
+++ b/group_test.go
@@ -98,7 +98,7 @@ func TestGroupListenAndServe_duplicated_stream(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg := &Group{}
+	pg := &Group{ErrorLog: discardLogger}
 
 	if err := pg.ListenAndServe([]Stream{stream1, stream2, stream1}); !errors.Is(err, ErrDuplicatedStream) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrDuplicatedStream)
@@ -110,7 +110,7 @@ func TestGroupListenAndServe_duplicated_stream(t *testing.T) {
 }
 
 func TestGroupClose_twice(t *testing.T) {
-	pg := &Group{}
+	pg := &Group{ErrorLog: discardLogger}
 
 	for i := 0; i < 2; i++ {
 		if err := pg.Close(); err != nil {
@@ -127,7 +127,7 @@ func TestGroupBeforeAccept(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg := &Group{}
+	pg := &Group{ErrorLog: discardLogger}
 	pg.BeforeAccept = func() error {
 		return wantErr
 	}
@@ -207,7 +207,7 @@ func TestParseStream(t *testing.T) {
 }
 
 func newTestGroup(streams []Stream) (*Group, <-chan error) {
-	pg := &Group{}
+	pg := &Group{ErrorLog: discardLogger}
 
 	var wg sync.WaitGroup
 	pg.BeforeAccept = func() error {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
 )
+
+var discardLogger = log.New(io.Discard, "", 0)
 
 func TestProxyListenAndServe(t *testing.T) {
 	want := "Test Response Body"
@@ -83,7 +86,7 @@ func TestProxyListenAndServe_after_close(t *testing.T) {
 }
 
 func TestProxyListenAndServe_after_close_without_listening(t *testing.T) {
-	p := &Proxy{}
+	p := &Proxy{ErrorLog: discardLogger}
 
 	if err := p.Close(); err != ErrProxyNotListening {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrProxyNotListening)
@@ -111,7 +114,7 @@ func TestProxyServe_after_close(t *testing.T) {
 }
 
 func TestProxyClose_without_listening(t *testing.T) {
-	p := &Proxy{}
+	p := &Proxy{ErrorLog: discardLogger}
 
 	if err := p.Close(); err != ErrProxyNotListening {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrProxyNotListening)
@@ -137,7 +140,7 @@ func TestProxyClose_twice(t *testing.T) {
 func TestProxyBeforeAccept(t *testing.T) {
 	wantErr := errors.New("BeforeAccept error")
 
-	p := &Proxy{}
+	p := &Proxy{ErrorLog: discardLogger}
 	p.BeforeAccept = func() error {
 		return wantErr
 	}
@@ -152,7 +155,7 @@ func TestProxyBeforeAccept(t *testing.T) {
 }
 
 func newTestProxy(listenNetwork, listenAddr, dialNetwork, dialAddr string) (*Proxy, <-chan error) {
-	p := &Proxy{}
+	p := &Proxy{ErrorLog: discardLogger}
 
 	var wg sync.WaitGroup
 	p.BeforeAccept = func() error {


### PR DESCRIPTION
This PR fixes the following issues:

- cmd/proxy: fix tests to connect to the proxy listener
- proxy: disable logs in tests