### PR TITLE
proxy: refactor *Group.ListenAndServe to return an error channel

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -39,8 +39,7 @@ func run(ctx context.Context, pg *proxy.Group, args []string) error {
 		return fmt.Errorf("parse arguments: %v", err)
 	}
 
-	errc := make(chan error)
-	go func() { errc <- pg.ListenAndServe(streams) }()
+	errc := pg.ListenAndServe(streams)
 
 	select {
 	case <-ctx.Done():

--- a/group.go
+++ b/group.go
@@ -12,7 +12,7 @@ import (
 var (
 	// ErrGroupClosed is returned by the *Group.ListenAndServe
 	// method after a call to *Group.Close.
-	ErrGroupClosed = errors.New("proxy group closed")
+	ErrGroupClosed = errors.New("Group closed")
 
 	// ErrDuplicatedStream is returned by the
 	// *Group.ListenAndServe method when it is called with


### PR DESCRIPTION
This change allows to receive the errors coming from the proxies
spawned by the Group as soon as they happen.