### PR TITLE
go.mod: retract published v1 versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/jroimartin/proxy
 
-go 1.21.0
+go 1.21.1
+
+retract [v1.0.0, v1.2.5] // v1 was published prematurely.


### PR DESCRIPTION
v1 was published prematurely.