### PR TITLE
proxy: fix bug in Group when handling duplicated streams

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,28 @@
 linters:
   enable:
-    - gofmt
-    - whitespace
+    - gci
     - godot
-    - revive # in place of deprecated golint
+    - gofmt
+    - misspell
+    - revive
+    - whitespace
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/jroimartin/proxy)
+    custom-order: true
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-use-default: false
+  exclude-rules:
+    - linters:
+        - errcheck
+      text: 'Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked'
+    - linters:
+        - revive
+      text: 'unused-parameter: parameter ''.*'' seems to be unused'
+run:
+  timeout: 5m

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -55,7 +55,7 @@ func run(ctx context.Context, pg *proxy.Group, args []string) error {
 		return fmt.Errorf("parse arguments: %v", err)
 	}
 
-	errc := pg.ListenAndServe(streams)
+	errc := pg.ListenAndServe(streams...)
 
 	select {
 	case <-ctx.Done():

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -65,7 +65,7 @@ func TestRun(t *testing.T) {
 		}
 
 		if !bytes.Equal(got, want) {
-			t.Errorf("unexpected reponse: got: %s, want: %s", got, want)
+			t.Errorf("unexpected response: got: %s, want: %s", got, want)
 		}
 	}
 

--- a/group.go
+++ b/group.go
@@ -136,6 +136,7 @@ func (pg *Group) closing() bool {
 	return pg.inClose.Load()
 }
 
+// Proxy returns the proxy that handles the provided stream.
 func (pg *Group) Proxy(stream Stream) *Proxy {
 	pg.mu.Lock()
 	defer pg.mu.Unlock()

--- a/group.go
+++ b/group.go
@@ -41,16 +41,11 @@ type Group struct {
 // ListenAndServe establishes the specified data streams. The returned
 // channel can be used to receive the errors coming from the [Group]
 // and the underneath [Proxy]'s.
-func (pg *Group) ListenAndServe(streams []Stream) <-chan error {
+func (pg *Group) ListenAndServe(streams ...Stream) <-chan error {
 	errc := make(chan error)
 
 	if pg.closing() {
 		go func() { errc <- ErrGroupClosed }()
-		return errc
-	}
-
-	if err := validateStreams(streams); err != nil {
-		go func() { errc <- fmt.Errorf("stream validation: %w", err) }()
 		return errc
 	}
 
@@ -101,6 +96,12 @@ func (pg *Group) trackProxy(stream Stream, p *Proxy, add bool) error {
 		if pg.closing() {
 			return ErrGroupClosed
 		}
+
+		_, dup := pg.proxies[stream]
+		if dup {
+			return ErrDuplicatedStream
+		}
+
 		pg.proxies[stream] = p
 		pg.proxiesGroup.Add(1)
 	} else {
@@ -195,17 +196,6 @@ func parseAddr(s string) (network, addr string, err error) {
 	}
 
 	return network, addr, nil
-}
-
-func validateStreams(streams []Stream) error {
-	for i := 0; i < len(streams); i++ {
-		for j := i + 1; j < len(streams); j++ {
-			if streams[i] == streams[j] {
-				return ErrDuplicatedStream
-			}
-		}
-	}
-	return nil
 }
 
 // String returns the string representation of the stream.

--- a/group_test.go
+++ b/group_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestGroupListenAndServe(t *testing.T) {
+func TestGroup_ListenAndServe(t *testing.T) {
 	const nproxies = 5
 
 	var streams []Stream
@@ -72,7 +72,7 @@ func TestGroupListenAndServe(t *testing.T) {
 	}
 }
 
-func TestGroupListenAndServe_after_close(t *testing.T) {
+func TestGroup_ListenAndServe_after_close(t *testing.T) {
 	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
 	if err != nil {
 		t.Fatalf("could not parse stream: %v", err)
@@ -93,7 +93,7 @@ func TestGroupListenAndServe_after_close(t *testing.T) {
 	}
 }
 
-func TestGroupListenAndServe_duplicated_stream(t *testing.T) {
+func TestGroup_ListenAndServe_duplicated_stream(t *testing.T) {
 	stream1, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
 	if err != nil {
 		t.Fatalf("could not parse stream: %v", err)
@@ -114,7 +114,7 @@ func TestGroupListenAndServe_duplicated_stream(t *testing.T) {
 	}
 }
 
-func TestGroupListenAndServe_duplicated_listener(t *testing.T) {
+func TestGroup_ListenAndServe_duplicated_listener(t *testing.T) {
 	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
 	if err != nil {
 		t.Fatalf("could not parse stream: %v", err)
@@ -145,7 +145,7 @@ func TestGroupListenAndServe_duplicated_listener(t *testing.T) {
 	}
 }
 
-func TestGroupClose_twice(t *testing.T) {
+func TestGroup_Close_twice(t *testing.T) {
 	pg := &Group{}
 
 	for i := 0; i < 2; i++ {
@@ -155,7 +155,7 @@ func TestGroupClose_twice(t *testing.T) {
 	}
 }
 
-func TestGroupBeforeAccept(t *testing.T) {
+func TestGroup_BeforeAccept(t *testing.T) {
 	wantErr := errors.New("BeforeAccept error")
 
 	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
@@ -177,7 +177,7 @@ func TestGroupBeforeAccept(t *testing.T) {
 	}
 }
 
-func TestGroupProxy(t *testing.T) {
+func TestGroup_Proxy(t *testing.T) {
 	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
 	if err != nil {
 		t.Fatalf("could not parse stream: %v", err)
@@ -198,7 +198,7 @@ func TestGroupProxy(t *testing.T) {
 	}
 }
 
-func TestGroupProxy_after_close(t *testing.T) {
+func TestGroup_Proxy_after_close(t *testing.T) {
 	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
 	if err != nil {
 		t.Fatalf("could not parse stream: %v", err)

--- a/group_test.go
+++ b/group_test.go
@@ -59,7 +59,7 @@ func TestGroup_ListenAndServe(t *testing.T) {
 
 		want := resps[s]
 		if !bytes.Equal(got, want) {
-			t.Errorf("unexpected reponse: got: %s, want: %s", got, want)
+			t.Errorf("unexpected response: got: %s, want: %s", got, want)
 		}
 	}
 

--- a/group_test.go
+++ b/group_test.go
@@ -35,14 +35,17 @@ func TestGroup_ListenAndServe(t *testing.T) {
 		resps[stream] = []byte(resp)
 	}
 
-	pg, errc := newTestGroup(streams)
+	pg, errc := newTestGroup(streams...)
 
+	urls := make(map[Stream]string)
 	pg.mu.Lock()
-	proxies := pg.proxies
+	for s, p := range pg.proxies {
+		urls[s] = "http://" + p.Addr().String()
+	}
 	pg.mu.Unlock()
 
-	for s, p := range proxies {
-		resp, err := http.Get("http://" + p.Addr().String())
+	for s, u := range urls {
+		resp, err := http.Get(u)
 		if err != nil {
 			t.Fatalf("HTTP GET request error: %v", err)
 		}
@@ -72,13 +75,188 @@ func TestGroup_ListenAndServe(t *testing.T) {
 	}
 }
 
+func TestGroup_ListenAndServe_multiple_calls(t *testing.T) {
+	const (
+		nproxies = 5
+		batchsz  = 2
+	)
+
+	streams := make([]Stream, nproxies)
+	resps := make(map[Stream][]byte, nproxies)
+	for i := 0; i < nproxies; i++ {
+		resp := fmt.Sprintf("response from server %v", i)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, resp)
+		}))
+		defer ts.Close()
+
+		tsAddr := ts.Listener.Addr()
+		stream, err := ParseStream(fmt.Sprintf("tcp:127.0.0.1:0,%v:%v", tsAddr.Network(), tsAddr))
+		if err != nil {
+			t.Fatalf("could no parse stream: %v", err)
+		}
+
+		streams[i] = stream
+		resps[stream] = []byte(resp)
+	}
+
+	pg := &Group{}
+
+	var wg sync.WaitGroup
+	pg.BeforeAccept = func() error {
+		wg.Done()
+		return nil
+	}
+
+	var errcs []<-chan error
+	for i := 0; i < nproxies; i += batchsz {
+		sz := min(batchsz, len(streams)-i)
+		batch := streams[i : i+sz]
+
+		wg.Add(sz)
+		errc := pg.ListenAndServe(batch...)
+		errcs = append(errcs, errc)
+	}
+
+	wg.Wait()
+
+	urls := make(map[Stream]string)
+	pg.mu.Lock()
+	for s, p := range pg.proxies {
+		urls[s] = "http://" + p.Addr().String()
+	}
+	pg.mu.Unlock()
+
+	for s, u := range urls {
+		resp, err := http.Get(u)
+		if err != nil {
+			t.Fatalf("HTTP GET request error: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("unexpected status code: got: %v, want: 200", resp.StatusCode)
+		}
+
+		got, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("error reading response body: %v", err)
+		}
+
+		want := resps[s]
+		if !bytes.Equal(got, want) {
+			t.Errorf("unexpected response: got: %s, want: %s", got, want)
+		}
+	}
+
+	if err := pg.Close(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	for _, errc := range errcs {
+		if err := <-errc; !errors.Is(err, ErrGroupClosed) {
+			t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
+		}
+	}
+}
+
+func TestGroup_ListenAndServe_multiple_calls_one_stream(t *testing.T) {
+	const (
+		want   = "response from server"
+		ncalls = 5
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, want)
+	}))
+	defer ts.Close()
+
+	tsAddr := ts.Listener.Addr()
+	stream, err := ParseStream(fmt.Sprintf("tcp:127.0.0.1:0,%v:%v", tsAddr.Network(), tsAddr))
+	if err != nil {
+		t.Fatalf("could no parse stream: %v", err)
+	}
+
+	pg := &Group{}
+
+	var wg sync.WaitGroup
+	pg.BeforeAccept = func() error {
+		wg.Done()
+		return nil
+	}
+
+	var errcs []<-chan error
+	wg.Add(1) // There is only 1 different stream.
+	for i := 0; i < ncalls; i++ {
+		errc := pg.ListenAndServe(stream)
+		errcs = append(errcs, errc)
+	}
+
+	wg.Wait()
+
+	resp, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("HTTP GET request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: got: %v, want: 200", resp.StatusCode)
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("error reading response body: %v", err)
+	}
+
+	if string(got) != want {
+		t.Errorf("unexpected response: got: %s, want: %s", got, want)
+	}
+
+	if err := pg.Close(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	var nDupErr, nCloseErr int
+	for _, errc := range errcs {
+		var seenDupErr, seenCloseErr bool
+		for err := range errc {
+			switch {
+			case errors.Is(err, ErrDuplicatedStream):
+				if seenDupErr || seenCloseErr {
+					t.Errorf("unexpected ErrDuplicatedStream error")
+				}
+				seenDupErr = true
+				nDupErr++
+			case errors.Is(err, ErrGroupClosed):
+				if seenCloseErr {
+					t.Errorf("unexpected ErrGroupClosed error")
+				}
+				seenCloseErr = true
+				nCloseErr++
+			default:
+				t.Errorf("unexpected error: %v", err)
+			}
+		}
+	}
+
+	if nDupErr != ncalls-1 {
+		t.Errorf("unexpected number of ErrDuplicatedStream errors: got: %v, want: %v", nDupErr, ncalls-1)
+	}
+
+	if nCloseErr != ncalls {
+		t.Errorf("unexpected number of ErrGroupClosed errors: got: %v, want: %v", nCloseErr, ncalls)
+	}
+}
+
 func TestGroup_ListenAndServe_after_close(t *testing.T) {
 	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
 	if err != nil {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg, errc := newTestGroup([]Stream{stream})
+	pg, errc := newTestGroup(stream)
 
 	if err := pg.Close(); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -88,7 +266,7 @@ func TestGroup_ListenAndServe_after_close(t *testing.T) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
 	}
 
-	if err := <-pg.ListenAndServe([]Stream{stream}); !errors.Is(err, ErrGroupClosed) {
+	if err := <-pg.ListenAndServe(stream); !errors.Is(err, ErrGroupClosed) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
 	}
 }
@@ -105,12 +283,28 @@ func TestGroup_ListenAndServe_duplicated_stream(t *testing.T) {
 
 	pg := &Group{}
 
-	if err := <-pg.ListenAndServe([]Stream{stream1, stream2, stream1}); !errors.Is(err, ErrDuplicatedStream) {
+	var wg sync.WaitGroup
+	pg.BeforeAccept = func() error {
+		wg.Done()
+		return nil
+	}
+
+	wg.Add(2) // There are 2 different streams.
+	errc := pg.ListenAndServe(stream1, stream2, stream1)
+	wg.Wait()
+
+	if err := <-errc; !errors.Is(err, ErrDuplicatedStream) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrDuplicatedStream)
 	}
 
 	if err := pg.Close(); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+
+	for err := range errc {
+		if !errors.Is(err, ErrGroupClosed) {
+			t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
+		}
 	}
 }
 
@@ -120,7 +314,7 @@ func TestGroup_ListenAndServe_duplicated_listener(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg, errc := newTestGroup([]Stream{stream})
+	pg, errc := newTestGroup(stream)
 
 	p := pg.Proxy(stream)
 	if p == nil {
@@ -132,7 +326,7 @@ func TestGroup_ListenAndServe_duplicated_listener(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	if err := <-pg.ListenAndServe([]Stream{stream}); !errors.Is(err, syscall.EADDRINUSE) {
+	if err := <-pg.ListenAndServe(stream); !errors.Is(err, syscall.EADDRINUSE) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, syscall.EADDRINUSE)
 	}
 
@@ -168,7 +362,7 @@ func TestGroup_BeforeAccept(t *testing.T) {
 		return wantErr
 	}
 
-	if err := <-pg.ListenAndServe([]Stream{stream}); !errors.Is(err, wantErr) {
+	if err := <-pg.ListenAndServe(stream); !errors.Is(err, wantErr) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, wantErr)
 	}
 
@@ -183,7 +377,7 @@ func TestGroup_Proxy(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg, errc := newTestGroup([]Stream{stream})
+	pg, errc := newTestGroup(stream)
 
 	if p := pg.Proxy(stream); p == nil {
 		t.Errorf("could not get proxy")
@@ -204,7 +398,7 @@ func TestGroup_Proxy_after_close(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg, errc := newTestGroup([]Stream{stream})
+	pg, errc := newTestGroup(stream)
 
 	if err := pg.Close(); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -284,7 +478,7 @@ func TestParseStream(t *testing.T) {
 	}
 }
 
-func newTestGroup(streams []Stream) (*Group, <-chan error) {
+func newTestGroup(streams ...Stream) (*Group, <-chan error) {
 	pg := &Group{}
 
 	var wg sync.WaitGroup
@@ -294,7 +488,7 @@ func newTestGroup(streams []Stream) (*Group, <-chan error) {
 	}
 
 	wg.Add(len(streams))
-	errc := pg.ListenAndServe(streams)
+	errc := pg.ListenAndServe(streams...)
 	wg.Wait()
 
 	return pg, errc

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestProxyListenAndServe(t *testing.T) {
+func TestProxy_ListenAndServe(t *testing.T) {
 	want := "Test Response Body"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +51,7 @@ func TestProxyListenAndServe(t *testing.T) {
 	}
 }
 
-func TestProxyListenAndServe_twice(t *testing.T) {
+func TestProxy_ListenAndServe_twice(t *testing.T) {
 	p, errc := newTestProxy("tcp", "127.0.0.1:0", "tcp", "127.0.0.1:1234")
 
 	if err := p.ListenAndServe("tcp", "127.0.0.1:0", "tcp", "127.0.0.1:1234"); !errors.Is(err, ErrProxyListening) {
@@ -67,7 +67,7 @@ func TestProxyListenAndServe_twice(t *testing.T) {
 	}
 }
 
-func TestProxyListenAndServe_after_close(t *testing.T) {
+func TestProxy_ListenAndServe_after_close(t *testing.T) {
 	p, errc := newTestProxy("tcp", "127.0.0.1:0", "tcp", "127.0.0.1:1234")
 
 	if err := p.Close(); err != nil {
@@ -83,7 +83,7 @@ func TestProxyListenAndServe_after_close(t *testing.T) {
 	}
 }
 
-func TestProxyListenAndServe_after_close_without_listening(t *testing.T) {
+func TestProxy_ListenAndServe_after_close_without_listening(t *testing.T) {
 	p := &Proxy{}
 
 	if err := p.Close(); err != ErrProxyNotListening {
@@ -95,7 +95,7 @@ func TestProxyListenAndServe_after_close_without_listening(t *testing.T) {
 	}
 }
 
-func TestProxyServe_after_close(t *testing.T) {
+func TestProxy_Serve_after_close(t *testing.T) {
 	p, errc := newTestProxy("tcp", "127.0.0.1:0", "tcp", "127.0.0.1:1234")
 
 	if err := p.Close(); err != nil {
@@ -111,7 +111,7 @@ func TestProxyServe_after_close(t *testing.T) {
 	}
 }
 
-func TestProxyClose_without_listening(t *testing.T) {
+func TestProxy_Close_without_listening(t *testing.T) {
 	p := &Proxy{}
 
 	if err := p.Close(); err != ErrProxyNotListening {
@@ -119,7 +119,7 @@ func TestProxyClose_without_listening(t *testing.T) {
 	}
 }
 
-func TestProxyClose_twice(t *testing.T) {
+func TestProxy_Close_twice(t *testing.T) {
 	p, errc := newTestProxy("tcp", "127.0.0.1:0", "tcp", "127.0.0.1:1234")
 
 	if err := p.Close(); err != nil {
@@ -135,7 +135,7 @@ func TestProxyClose_twice(t *testing.T) {
 	}
 }
 
-func TestProxyBeforeAccept(t *testing.T) {
+func TestProxy_BeforeAccept(t *testing.T) {
 	wantErr := errors.New("BeforeAccept error")
 
 	p := &Proxy{}
@@ -152,7 +152,7 @@ func TestProxyBeforeAccept(t *testing.T) {
 	}
 }
 
-func TestProxyAddr(t *testing.T) {
+func TestProxy_Addr(t *testing.T) {
 	p := &Proxy{}
 
 	if addr := p.Addr(); addr != nil {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -39,7 +39,7 @@ func TestProxy_ListenAndServe(t *testing.T) {
 	}
 
 	if !bytes.Equal(got, []byte(want)) {
-		t.Errorf("unexpected reponse: got: %s, want: %s", got, want)
+		t.Errorf("unexpected response: got: %s, want: %s", got, want)
 	}
 
 	if err := p.Close(); err != nil {


### PR DESCRIPTION
This PR fixes a bug in `Group` that allowed to call
`*Group.ListenAndServe` multiple times with duplicated streams.

It also renames some test functions to match the convention
`TestT_M_suffix`.

Lastly, it enables `gci` and `misspell` in `.golangci.yml` and fixes
the issues reported by them.