### PR TITLE
proxy: replace BeforeAccept hook with events channel

### DIFF
--- a/group_test.go
+++ b/group_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"syscall"
 	"testing"
 )
@@ -16,7 +15,7 @@ func TestGroup_ListenAndServe(t *testing.T) {
 	const nproxies = 5
 
 	var streams []Stream
-	resps := make(map[Stream][]byte)
+	resps := make(map[string][]byte)
 	for i := 0; i < nproxies; i++ {
 		resp := fmt.Sprintf("response from server %v", i)
 
@@ -32,20 +31,28 @@ func TestGroup_ListenAndServe(t *testing.T) {
 		}
 
 		streams = append(streams, stream)
-		resps[stream] = []byte(resp)
+		resps[tsAddr.String()] = []byte(resp)
 	}
 
-	pg, errc := newTestGroup(streams...)
+	pg := NewGroup()
+	evc, errc := pg.ListenAndServe(streams...)
 
-	urls := make(map[Stream]string)
-	pg.mu.Lock()
-	for s, p := range pg.proxies {
-		urls[s] = "http://" + p.Addr().String()
+	pgStreams := make(map[string]string)
+	n := nproxies
+	for ev := range evc {
+		if ev.Kind != KindBeforeAccept {
+			continue
+		}
+		stream := ev.Data.(Stream)
+		pgStreams[stream.DialAddr] = stream.ListenAddr
+		n--
+		if n == 0 {
+			break
+		}
 	}
-	pg.mu.Unlock()
 
-	for s, u := range urls {
-		resp, err := http.Get(u)
+	for dialAddr, listenAddr := range pgStreams {
+		resp, err := http.Get("http://" + listenAddr)
 		if err != nil {
 			t.Fatalf("HTTP GET request error: %v", err)
 		}
@@ -60,7 +67,7 @@ func TestGroup_ListenAndServe(t *testing.T) {
 			t.Fatalf("error reading response body: %v", err)
 		}
 
-		want := resps[s]
+		want := resps[dialAddr]
 		if !bytes.Equal(got, want) {
 			t.Errorf("unexpected response: got: %s, want: %s", got, want)
 		}
@@ -82,7 +89,7 @@ func TestGroup_ListenAndServe_multiple_calls(t *testing.T) {
 	)
 
 	streams := make([]Stream, nproxies)
-	resps := make(map[Stream][]byte, nproxies)
+	resps := make(map[string][]byte, nproxies)
 	for i := 0; i < nproxies; i++ {
 		resp := fmt.Sprintf("response from server %v", i)
 
@@ -98,38 +105,35 @@ func TestGroup_ListenAndServe_multiple_calls(t *testing.T) {
 		}
 
 		streams[i] = stream
-		resps[stream] = []byte(resp)
+		resps[tsAddr.String()] = []byte(resp)
 	}
 
-	pg := &Group{}
-
-	var wg sync.WaitGroup
-	pg.BeforeAccept = func() error {
-		wg.Done()
-		return nil
-	}
+	pg := NewGroup()
 
 	var errcs []<-chan error
+	pgStreams := make(map[string]string)
 	for i := 0; i < nproxies; i += batchsz {
 		sz := min(batchsz, len(streams)-i)
 		batch := streams[i : i+sz]
 
-		wg.Add(sz)
-		errc := pg.ListenAndServe(batch...)
+		evc, errc := pg.ListenAndServe(batch...)
+		n := sz
+		for ev := range evc {
+			if ev.Kind != KindBeforeAccept {
+				continue
+			}
+			stream := ev.Data.(Stream)
+			pgStreams[stream.DialAddr] = stream.ListenAddr
+			n--
+			if n == 0 {
+				break
+			}
+		}
 		errcs = append(errcs, errc)
 	}
 
-	wg.Wait()
-
-	urls := make(map[Stream]string)
-	pg.mu.Lock()
-	for s, p := range pg.proxies {
-		urls[s] = "http://" + p.Addr().String()
-	}
-	pg.mu.Unlock()
-
-	for s, u := range urls {
-		resp, err := http.Get(u)
+	for dialAddr, listenAddr := range pgStreams {
+		resp, err := http.Get("http://" + listenAddr)
 		if err != nil {
 			t.Fatalf("HTTP GET request error: %v", err)
 		}
@@ -144,7 +148,7 @@ func TestGroup_ListenAndServe_multiple_calls(t *testing.T) {
 			t.Fatalf("error reading response body: %v", err)
 		}
 
-		want := resps[s]
+		want := resps[dialAddr]
 		if !bytes.Equal(got, want) {
 			t.Errorf("unexpected response: got: %s, want: %s", got, want)
 		}
@@ -178,22 +182,25 @@ func TestGroup_ListenAndServe_multiple_calls_one_stream(t *testing.T) {
 		t.Fatalf("could no parse stream: %v", err)
 	}
 
-	pg := &Group{}
+	pg := NewGroup()
 
-	var wg sync.WaitGroup
-	pg.BeforeAccept = func() error {
-		wg.Done()
-		return nil
-	}
-
-	var errcs []<-chan error
-	wg.Add(1) // There is only 1 different stream.
+	evcMux := make(chan Event)
+	errcMux := make(chan error)
 	for i := 0; i < ncalls; i++ {
-		errc := pg.ListenAndServe(stream)
-		errcs = append(errcs, errc)
+		evc, errc := pg.ListenAndServe(stream)
+		go func() {
+			for ev := range evc {
+				evcMux <- ev
+			}
+		}()
+		go func() {
+			for err := range errc {
+				errcMux <- err
+			}
+		}()
 	}
 
-	wg.Wait()
+	waitBeforeAccept(evcMux, 1)
 
 	resp, err := http.Get(ts.URL)
 	if err != nil {
@@ -214,39 +221,20 @@ func TestGroup_ListenAndServe_multiple_calls_one_stream(t *testing.T) {
 		t.Errorf("unexpected response: got: %s, want: %s", got, want)
 	}
 
+	for i := 0; i < ncalls-1; i++ {
+		if !errors.Is(<-errcMux, ErrDuplicatedStream) {
+			t.Errorf("unexpected error: got: %v, want: %v", err, ErrDuplicatedStream)
+		}
+	}
+
 	if err := pg.Close(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	var nDupErr, nCloseErr int
-	for _, errc := range errcs {
-		var seenDupErr, seenCloseErr bool
-		for err := range errc {
-			switch {
-			case errors.Is(err, ErrDuplicatedStream):
-				if seenDupErr || seenCloseErr {
-					t.Errorf("unexpected ErrDuplicatedStream error")
-				}
-				seenDupErr = true
-				nDupErr++
-			case errors.Is(err, ErrGroupClosed):
-				if seenCloseErr {
-					t.Errorf("unexpected ErrGroupClosed error")
-				}
-				seenCloseErr = true
-				nCloseErr++
-			default:
-				t.Errorf("unexpected error: %v", err)
-			}
+	for i := 0; i < ncalls; i++ {
+		if errors.Is(err, ErrGroupClosed) {
+			t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
 		}
-	}
-
-	if nDupErr != ncalls-1 {
-		t.Errorf("unexpected number of ErrDuplicatedStream errors: got: %v, want: %v", nDupErr, ncalls-1)
-	}
-
-	if nCloseErr != ncalls {
-		t.Errorf("unexpected number of ErrGroupClosed errors: got: %v, want: %v", nCloseErr, ncalls)
 	}
 }
 
@@ -256,7 +244,8 @@ func TestGroup_ListenAndServe_after_close(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg, errc := newTestGroup(stream)
+	pg := NewGroup()
+	_, errc := pg.ListenAndServe(stream)
 
 	if err := pg.Close(); err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -266,7 +255,7 @@ func TestGroup_ListenAndServe_after_close(t *testing.T) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
 	}
 
-	if err := <-pg.ListenAndServe(stream); !errors.Is(err, ErrGroupClosed) {
+	if _, errc := pg.ListenAndServe(stream); !errors.Is(<-errc, ErrGroupClosed) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
 	}
 }
@@ -281,17 +270,11 @@ func TestGroup_ListenAndServe_duplicated_stream(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg := &Group{}
+	pg := NewGroup()
 
-	var wg sync.WaitGroup
-	pg.BeforeAccept = func() error {
-		wg.Done()
-		return nil
-	}
+	evc, errc := pg.ListenAndServe(stream1, stream2, stream1)
 
-	wg.Add(2) // There are 2 different streams.
-	errc := pg.ListenAndServe(stream1, stream2, stream1)
-	wg.Wait()
+	waitBeforeAccept(evc, 2)
 
 	if err := <-errc; !errors.Is(err, ErrDuplicatedStream) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, ErrDuplicatedStream)
@@ -314,19 +297,23 @@ func TestGroup_ListenAndServe_duplicated_listener(t *testing.T) {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	pg, errc := newTestGroup(stream)
+	pg := NewGroup()
+	evc, errc := pg.ListenAndServe(stream)
 
-	p := pg.Proxy(stream)
-	if p == nil {
-		t.Fatalf("could not get proxy")
+	var listenAddr string
+	for ev := range evc {
+		if ev.Kind == KindBeforeAccept {
+			listenAddr = ev.Data.(Stream).ListenAddr
+			break
+		}
 	}
 
-	stream, err = ParseStream(fmt.Sprintf("tcp:%v,tcp:127.0.0.1:1234", p.Addr()))
+	stream, err = ParseStream(fmt.Sprintf("tcp:%v,tcp:127.0.0.1:1234", listenAddr))
 	if err != nil {
 		t.Fatalf("could not parse stream: %v", err)
 	}
 
-	if err := <-pg.ListenAndServe(stream); !errors.Is(err, syscall.EADDRINUSE) {
+	if _, errc := pg.ListenAndServe(stream); !errors.Is(<-errc, syscall.EADDRINUSE) {
 		t.Errorf("unexpected error: got: %v, want: %v", err, syscall.EADDRINUSE)
 	}
 
@@ -340,156 +327,11 @@ func TestGroup_ListenAndServe_duplicated_listener(t *testing.T) {
 }
 
 func TestGroup_Close_twice(t *testing.T) {
-	pg := &Group{}
+	pg := NewGroup()
 
 	for i := 0; i < 2; i++ {
 		if err := pg.Close(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	}
-}
-
-func TestGroup_BeforeAccept(t *testing.T) {
-	wantErr := errors.New("BeforeAccept error")
-
-	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
-	if err != nil {
-		t.Fatalf("could not parse stream: %v", err)
-	}
-
-	pg := &Group{}
-	pg.BeforeAccept = func() error {
-		return wantErr
-	}
-
-	if err := <-pg.ListenAndServe(stream); !errors.Is(err, wantErr) {
-		t.Errorf("unexpected error: got: %v, want: %v", err, wantErr)
-	}
-
-	if err := pg.Close(); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-func TestGroup_Proxy(t *testing.T) {
-	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
-	if err != nil {
-		t.Fatalf("could not parse stream: %v", err)
-	}
-
-	pg, errc := newTestGroup(stream)
-
-	if p := pg.Proxy(stream); p == nil {
-		t.Errorf("could not get proxy")
-	}
-
-	if err := pg.Close(); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if err := <-errc; !errors.Is(err, ErrGroupClosed) {
-		t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
-	}
-}
-
-func TestGroup_Proxy_after_close(t *testing.T) {
-	stream, err := ParseStream("tcp:127.0.0.1:0,tcp:127.0.0.1:1234")
-	if err != nil {
-		t.Fatalf("could not parse stream: %v", err)
-	}
-
-	pg, errc := newTestGroup(stream)
-
-	if err := pg.Close(); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if p := pg.Proxy(stream); p != nil {
-		t.Errorf("unexpected proxy: %v", p)
-	}
-
-	if err := <-errc; !errors.Is(err, ErrGroupClosed) {
-		t.Errorf("unexpected error: got: %v, want: %v", err, ErrGroupClosed)
-	}
-}
-
-func TestParseStream(t *testing.T) {
-	tests := []struct {
-		name       string
-		stream     string
-		want       Stream
-		wantNilErr bool
-	}{
-		{
-			name:   "valid",
-			stream: "tcp::1234,unix:/path/to/socket",
-			want: Stream{
-				listenNetwork: "tcp",
-				listenAddr:    ":1234",
-				dialNetwork:   "unix",
-				dialAddr:      "/path/to/socket",
-			},
-			wantNilErr: true,
-		},
-		{
-			name:       "malformed",
-			stream:     "tcp::1234:unix:/path/to/socket",
-			want:       Stream{},
-			wantNilErr: false,
-		},
-		{
-			name:       "empty listener",
-			stream:     ",unix:/path/to/socket",
-			want:       Stream{},
-			wantNilErr: false,
-		},
-		{
-			name:       "empty target",
-			stream:     "tcp::1234,",
-			want:       Stream{},
-			wantNilErr: false,
-		},
-		{
-			name:       "empty network",
-			stream:     "::1234,unix:/path/to/socket",
-			want:       Stream{},
-			wantNilErr: false,
-		},
-		{
-			name:       "empty address",
-			stream:     "tcp:,unix:/path/to/socket",
-			want:       Stream{},
-			wantNilErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseStream(tt.stream)
-
-			if got != tt.want {
-				t.Errorf("unexpected stream: got: %v, want: %v", got, tt.want)
-			}
-
-			if (err == nil) != tt.wantNilErr {
-				t.Errorf("unexpected error: %v", err)
-			}
-		})
-	}
-}
-
-func newTestGroup(streams ...Stream) (*Group, <-chan error) {
-	pg := &Group{}
-
-	var wg sync.WaitGroup
-	pg.BeforeAccept = func() error {
-		wg.Done()
-		return nil
-	}
-
-	wg.Add(len(streams))
-	errc := pg.ListenAndServe(streams...)
-	wg.Wait()
-
-	return pg, errc
 }

--- a/proxy.go
+++ b/proxy.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -16,15 +17,13 @@ var (
 	// *Proxy.ListenAndServe methods after a call to *Proxy.Close.
 	ErrProxyClosed = errors.New("Proxy closed")
 
-	// ErrProxyNotListening is returned by the *Proxy.Close method
-	// if the listener has not been set yet or if it has been
-	// already closed.
-	ErrProxyNotListening = errors.New("Proxy is not listening")
-
-	// ErrProxyListening is returned by the *Proxy.Serve and
-	// *Proxy.ListenAndServe methods if the Proxy is already
-	// listening.
-	ErrProxyListening = errors.New("Proxy listening")
+	// ErrProxyListener is returned in the following
+	// circumstances:
+	//   - *Proxy.Close is called before the listener has been set
+	//     or after it has been closed.
+	//   - *Proxy.Serve or *Proxy.ListenAndServe is called after
+	//     the Proxy is already listening.
+	ErrProxyListener = errors.New("Proxy listener error")
 )
 
 // Proxy represents a proxy server.
@@ -33,17 +32,21 @@ type Proxy struct {
 	// logging is done via the log package's standard logger.
 	ErrorLog *log.Logger
 
-	// BeforeAccept is called when the listener is ready, just
-	// before accepting connections.
-	BeforeAccept func() error
-
-	inClose atomic.Bool
+	inClose       atomic.Bool
+	listenerGroup sync.WaitGroup
+	evc           chan Event
 
 	mu       sync.Mutex
 	conn     map[net.Conn]struct{}
 	listener net.Listener
+}
 
-	listenerGroup sync.WaitGroup
+// NewProxy initializes and returns a new [Proxy].
+func NewProxy() *Proxy {
+	return &Proxy{
+		conn: make(map[net.Conn]struct{}),
+		evc:  make(chan Event),
+	}
 }
 
 // ListenAndServe listens on the specified "listen network address"
@@ -69,11 +72,15 @@ func (p *Proxy) Serve(l net.Listener, dialNetwork, dialAddress string) error {
 	}
 	defer p.trackListener(l, false) //nolint:errcheck
 
-	if p.BeforeAccept != nil {
-		if err := p.BeforeAccept(); err != nil {
-			return err
-		}
-	}
+	p.sendEvent(Event{
+		Kind: KindBeforeAccept,
+		Data: Stream{
+			ListenNetwork: l.Addr().Network(),
+			ListenAddr:    l.Addr().String(),
+			DialNetwork:   dialNetwork,
+			DialAddr:      dialAddress,
+		},
+	})
 
 	for {
 		listenConn, err := l.Accept()
@@ -115,16 +122,10 @@ func (p *Proxy) serve(listenConn net.Conn, dialNetwork, dialAddress string) {
 	wg.Wait()
 }
 
-// Addr returns the network address of the internal [net.Listener]. It
-// returns nil if the proxy is not listening.
-func (p *Proxy) Addr() net.Addr {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if p.listener == nil {
-		return nil
-	}
-	return p.listener.Addr()
+// Events returns an [Event] channel that can be used to receive
+// events published by the [Proxy].
+func (p *Proxy) Events() <-chan Event {
+	return p.evc
 }
 
 // Close closes the internal [net.Listener] and any active connection.
@@ -147,7 +148,7 @@ func (p *Proxy) trackListener(l net.Listener, set bool) error {
 			return ErrProxyClosed
 		}
 		if p.listener != nil {
-			return ErrProxyListening
+			return ErrProxyListener
 		}
 		p.listener = l
 		p.listenerGroup.Add(1)
@@ -163,7 +164,7 @@ func (p *Proxy) closeListener() error {
 	defer p.mu.Unlock()
 
 	if p.listener == nil {
-		return ErrProxyNotListening
+		return ErrProxyListener
 	}
 	return p.listener.Close()
 }
@@ -171,10 +172,6 @@ func (p *Proxy) closeListener() error {
 func (p *Proxy) trackConn(conn net.Conn, add bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	if p.conn == nil {
-		p.conn = make(map[net.Conn]struct{})
-	}
 
 	if add {
 		p.conn[conn] = struct{}{}
@@ -197,10 +194,100 @@ func (p *Proxy) closing() bool {
 	return p.inClose.Load()
 }
 
+func (p *Proxy) sendEvent(ev Event) {
+	go func() { p.evc <- ev }()
+}
+
 func (p *Proxy) logf(format string, args ...any) {
 	if p.ErrorLog != nil {
 		p.ErrorLog.Printf(format, args...)
 	} else {
 		log.Printf(format, args...)
 	}
+}
+
+// An Event represents an update in the internal state of the proxy.
+// The type of the Data field depends on the kind of event.
+type Event struct {
+	Kind Kind
+	Data any
+}
+
+// Kind is the kind of [Event].
+type Kind int
+
+const (
+	// KindBeforeAccept refers to the event sent just before the
+	// Proxy starts accepting connections. The Event.Data field
+	// contains the related Stream.
+	KindBeforeAccept Kind = iota
+)
+
+// Stream represents a bidirectional data stream.
+type Stream struct {
+	// ListenNetwork is the name of the network of the listener.
+	ListenNetwork string
+
+	// ListenAddr is the address of the listener.
+	ListenAddr string
+
+	// DialNetwork is the name of the dialed network.
+	DialNetwork string
+
+	// DialAddr is the dialed address.
+	DialAddr string
+}
+
+// ParseStream parses a string representing a bidirectional data
+// stream with the format:
+//
+//	<listen network>:<listen address>,<dial network>:<dial address>".
+func ParseStream(s string) (Stream, error) {
+	sides := strings.Split(s, ",")
+	if len(sides) != 2 {
+		return Stream{}, fmt.Errorf("malformed stream %q", s)
+	}
+
+	listenNetwork, listenAddr, err := parseAddr(sides[0])
+	if err != nil {
+		return Stream{}, fmt.Errorf("malformed listen side %q: %w", sides[0], err)
+	}
+
+	dialNetwork, dialAddr, err := parseAddr(sides[1])
+	if err != nil {
+		return Stream{}, fmt.Errorf("malformed dial side %q: %w", sides[1], err)
+	}
+
+	stream := Stream{
+		ListenNetwork: listenNetwork,
+		ListenAddr:    listenAddr,
+		DialNetwork:   dialNetwork,
+		DialAddr:      dialAddr,
+	}
+
+	return stream, nil
+}
+
+func parseAddr(s string) (network, addr string, err error) {
+	i := strings.Index(s, ":")
+	if i < 0 {
+		return "", "", fmt.Errorf("malformed address")
+	}
+
+	network = s[:i]
+	if network == "" {
+		return "", "", errors.New("empty network")
+	}
+
+	addr = s[i+1:]
+	if addr == "" {
+		return "", "", errors.New("empty address")
+	}
+
+	return network, addr, nil
+}
+
+// String returns the string representation of the stream.
+func (stream Stream) String() string {
+	return fmt.Sprintf("%v:%v,%v:%v", stream.ListenNetwork, stream.ListenAddr, stream.DialNetwork, stream.DialAddr)
 }


### PR DESCRIPTION
This PR removes the `BeforeAccept` hook and introduces an events
channel in both `Proxy` and `Group`.