### PR TITLE
proxy: fix deadlock in *Proxy.closeEvents

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -226,11 +226,9 @@ func (p *Proxy) closeConn() {
 }
 
 // closeEvents closes de events channel after all the events have been
-// consumed.
+// consumed. This function expects to run on a goroutine created from
+// [*Proxy.Close].
 func (p *Proxy) closeEvents() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	p.eventGroup.Wait()
 	close(p.evc)
 }


### PR DESCRIPTION
Fixes a deadlock that happens when `*Proxy.Close` is called twice
existing pending events.

This bug was instroduced by:

e5ac824 proxy: fix deadlock in *Proxy.Serve